### PR TITLE
2017.2 で警告が出る問題を修正。

### DIFF
--- a/Assets/Plugins.meta
+++ b/Assets/Plugins.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 916b529e33580f64a9e79f55b22aa6cb
+folderAsset: yes
+timeCreated: 1512988149
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/WebGL.meta
+++ b/Assets/Plugins/WebGL.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: afae4342cf14c84478f036113965c46f
+folderAsset: yes
+timeCreated: 1512988150
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/WebGL/OpenWindow.jslib
+++ b/Assets/Plugins/WebGL/OpenWindow.jslib
@@ -1,0 +1,14 @@
+mergeInto(LibraryManager.library, {
+	OpenWindow: function(urlPtr) {
+		var url = Pointer_stringify(urlPtr);
+		var F = 0;
+		if (screen.height > 500) {
+			F = Math.round((screen.height / 2) - (250));
+		}
+		window.open(url,
+		'intent',
+		'left='+Math.round((screen.width/2)-(250))+',top='+F+
+		',width=500,height=260,personalbar=no,toolbar=no,resizable=no,scrollbars=yes');
+	}
+
+});

--- a/Assets/Plugins/WebGL/OpenWindow.jslib.meta
+++ b/Assets/Plugins/WebGL/OpenWindow.jslib.meta
@@ -1,0 +1,39 @@
+fileFormatVersion: 2
+guid: b02a4a026d5088d458160565629c2516
+timeCreated: 1512988156
+licenseType: Free
+PluginImporter:
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+    data:
+      first:
+        Any: 
+      second:
+        enabled: 0
+        settings: {}
+    data:
+      first:
+        Editor: Editor
+      second:
+        enabled: 0
+        settings:
+          DefaultValueInitialized: true
+    data:
+      first:
+        Facebook: WebGL
+      second:
+        enabled: 1
+        settings: {}
+    data:
+      first:
+        WebGL: WebGL
+      second:
+        enabled: 1
+        settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/naichilab/unityroom-tweet/UnityRoomTweet.cs
+++ b/Assets/naichilab/unityroom-tweet/UnityRoomTweet.cs
@@ -1,11 +1,15 @@
 ﻿using System.Text;
 using System.Linq;
 using UnityEngine;
+using System.Runtime.InteropServices;
 
 namespace naichilab
 {
 	public static class UnityRoomTweet
 	{
+		[DllImport("__Internal")]
+		private static extern void OpenWindow(string url);
+
 		const string GAMEURL = "https://unityroom.com/games/{0}";
 		const string WEBGLURL = "https://unityroom.com/games/{0}/webgl";
 		const string SHAREURL = "http://twitter.com/share?";
@@ -31,7 +35,11 @@ namespace naichilab
 			}
 
 			if (Application.platform == RuntimePlatform.WebGLPlayer) {
+#if UNITY_2017_2_OR_NEWER
+				OpenWindow(sb.ToString());
+#else
 				Application.ExternalEval ("var F = 0;if (screen.height > 500) {F = Math.round((screen.height / 2) - (250));}window.open('" + sb.ToString () + "','intent','left='+Math.round((screen.width/2)-(250))+',top='+F+',width=500,height=260,personalbar=no,toolbar=no,resizable=no,scrollbars=yes');");
+#endif
 			} else {
 				Debug.Log ("WebGL以外では実行できません。");
 				Debug.Log (sb.ToString ());


### PR DESCRIPTION
2017.2 のプロジェクトで利用してみたところ、Application.ExternalEval() が非推奨になったという警告が表示されました。そのため、Javascript のソース部分を jslib に移しました。
5.6 でも動作確認済です。
ご検討のほどよろしくお願い申し上げます。