### PR TITLE
WebGL以外ではOpenWindow()が無効のためIL2CPPがエラーになるので、プラットフォーム依存 #define で囲って回避

### DIFF
--- a/Assets/naichilab/unityroom-tweet/Scripts/UnityRoomTweet.cs
+++ b/Assets/naichilab/unityroom-tweet/Scripts/UnityRoomTweet.cs
@@ -6,8 +6,10 @@ namespace naichilab
 {
     public static class UnityRoomTweet
     {
+#if UNITY_WEBGL
         [DllImport("__Internal")]
         private static extern void OpenWindow(string url);
+#endif
 
         private static YieldInstruction _currentCoroutine = null;
 
@@ -62,10 +64,12 @@ namespace naichilab
         {
             if (Application.platform == RuntimePlatform.WebGLPlayer)
             {
+#if UNITY_WEBGL
 #if UNITY_2017_2_OR_NEWER
                 OpenWindow(tweetUrl);
 #else
 				Application.ExternalEval ("var F = 0;if (screen.height > 500) {F = Math.round((screen.height / 2) - (250));}window.open('" + tweetUrl + "','intent','left='+Math.round((screen.width/2)-(250))+',top='+F+',width=500,height=260,personalbar=no,toolbar=no,resizable=no,scrollbars=yes');");
+#endif
 #endif
             }
             else


### PR DESCRIPTION
こちらを使用したプロジェクトをそのままAndroid対応しようと思い、
`Scripting Backend: IL2CPP`でビルドしたら、呼び出していなくても以下のエラーになったため、
回避策として、OpenWindow周りを#if UNITY_WEBGLディレクティブで囲いました。
```
${ProjDir}/Library/il2cpp_android_armeabi-v7a/il2cpp_cache/6A2B8A05D149B3D067E66F08EC7C1266.o: In function `UnityRoomTweet_OpenWindow_m1487466012':
${ProjDir}/Temp/StagingArea/Il2Cpp/il2cppOutput/Bulk_Assembly-CSharp_3.cpp:45969: undefined reference to `OpenWindow'
${ProjDir}/Temp/StagingArea/Il2Cpp/il2cppOutput/Bulk_Assembly-CSharp_3.cpp:45969: undefined reference to `OpenWindow'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

IL2CPPではなくMonoだと大丈夫だったのですが、Android 64bit対応の件もありましたので…。
http://d.hatena.ne.jp/nakamura001/20180717/1531822914

`if (Application.platform == RuntimePlatform.WebGLPlayer)`と`#if UNITY_WEBGL`かぶせているのが体裁悪い感じもしますので、何らか方針ありましたら良きにはからっていただけますと幸いです。