### PR TITLE
ライブラリをUTF8ToStringに差し替える修正

### DIFF
--- a/Assets/naichilab/unityroom-tweet/Plugins/WebGL/OpenWindow.jslib
+++ b/Assets/naichilab/unityroom-tweet/Plugins/WebGL/OpenWindow.jslib
@@ -1,6 +1,6 @@
 mergeInto(LibraryManager.library, {
 	OpenWindow: function(urlPtr) {
-		var url = Pointer_stringify(urlPtr);
+		var url = UTF8ToString(urlPtr);
 		var F = 0;
 		if (screen.height > 500) {
 			F = Math.round((screen.height / 2) - (250));


### PR DESCRIPTION
* fix https://github.com/naichilab/unityroom-tweet/issues/7

こちらを取り入れる修正となります。
実機( https://unityroom.com/games/judge_donut_hole )にて、 以前では動作せず、こちらの修正後に意図した挙動が確認されました。